### PR TITLE
NR-15 DNSMadeEasy Unit Test Failing

### DIFF
--- a/src/integration-tests/java/com/netradius/dnsmadeeasy/TestConfig.java
+++ b/src/integration-tests/java/com/netradius/dnsmadeeasy/TestConfig.java
@@ -20,7 +20,8 @@ public class TestConfig {
 			"C:\\dnsmadeeasy-client.properties",
 			"/etc/dnsmadeeasy-client.properties",
 			System.getProperty("user.home") + "/dnsmadeeasy-client.properties",
-			System.getProperty("user.dir") + "/dnsmadeeasy-client.properties"};
+			System.getProperty("user.dir") + "/dnsmadeeasy-client.properties",
+			"src/main/resources/dnsmadeeasyclient.properties"};
 
 	private Properties properties;
 

--- a/src/main/resources/dnsmadeeasyclient.properties
+++ b/src/main/resources/dnsmadeeasyclient.properties
@@ -2,5 +2,5 @@
 # for preparing the config properties when using the Library, for usage please refer
 # com.netradius.dnsmadeeasy.TestConfig for more details
 rest.api.url = https://api.sandbox.dnsmadeeasy.com/V2.0
-rest.api.key = 4aadbed8-3a22-467b-8022-44e9456920b0
-rest.api.secret = 068b1d62-89b3-4555-bcf5-1e90be42a86a
+rest.api.key = a69a3a99-e6d0-4af4-a1dd-afbe17686098
+rest.api.secret = cf8c3a05-6815-48bb-85bb-2f7602d53eac


### PR DESCRIPTION
1) Fixed the original config file not found issue reported.
2) Fixed the SSLPeerUnverifiedException: Certificate for <api.sandbox.dnsmadeeasy.com> issue when trying to run the test.
3) A new account had to be created on the sandbox dnsmade easy and the rest api keys and secret added to the dnsmadeeasyclient properties to be used while the tests being executed.